### PR TITLE
Filter sensitive data from exception dump

### DIFF
--- a/lib/currency_cloud/errors/api_error.rb
+++ b/lib/currency_cloud/errors/api_error.rb
@@ -45,7 +45,7 @@ module CurrencyCloud
     def to_s
       class_name = super
 
-      string_params = Hash[@params.map { |k, v| [k.to_s, v.to_s]}]
+      string_params = Hash[@params.map { |k, v| [k.to_s, whitelist(k, v)] }]
 
       error_details = {
         'platform' => platform,

--- a/lib/currency_cloud/errors/error_utils.rb
+++ b/lib/currency_cloud/errors/error_utils.rb
@@ -1,5 +1,8 @@
 module CurrencyCloud
   module ErrorUtils
+    WHITELISTED_PARAMS = [:login_id, :api_key, :token].freeze
+    SANITIZED_VALUE = "[FILTERED]".freeze
+
     def platform
       base = "ruby-#{RUBY_VERSION}"
       implementation = case RUBY_ENGINE
@@ -9,6 +12,10 @@ module CurrencyCloud
                        else ' (other)'
                        end
       "#{base}#{implementation}"
+    end
+
+    def whitelist(param_key, param_value)
+      WHITELISTED_PARAMS.include?(param_key) ? SANITIZED_VALUE : param_value
     end
   end
 end

--- a/lib/currency_cloud/errors/unexpected_error.rb
+++ b/lib/currency_cloud/errors/unexpected_error.rb
@@ -15,7 +15,7 @@ module CurrencyCloud
     def to_s
       class_name = super
 
-      string_params = Hash[@params.map { |k, v| [k.to_s, v.to_s]}]
+      string_params = Hash[@params.map { |k, v| [k.to_s, whitelist(k, v)] }]
 
       error_details = {
         'platform' => platform,


### PR DESCRIPTION
This filters out sensitive params from the exceptions so it won't be logged or send to external tools for handling exception.
```
CurrencyCloud::BadRequestError: CurrencyCloud::BadRequestError
---
platform: ruby-2.3.1
request:
  parameters:
    login_id: "[FILTERED]"
    api_key: "[FILTERED]"
  verb: post
  url: https://devapi.thecurrencycloud.com/v2/authenticate/api
```