### PR TITLE
Add Reference.payment_dates

### DIFF
--- a/lib/currency_cloud/payment_dates.rb
+++ b/lib/currency_cloud/payment_dates.rb
@@ -1,0 +1,5 @@
+module CurrencyCloud
+  class PaymentDates
+    include CurrencyCloud::Resource
+  end
+end

--- a/lib/currency_cloud/reference.rb
+++ b/lib/currency_cloud/reference.rb
@@ -18,6 +18,11 @@ module CurrencyCloud
       ConversionDates.new(dates)
     end
 
+    def self.payment_dates(params)
+      dates = client.get('payment_dates', params)
+      PaymentDates.new(dates)
+    end
+
     def self.settlement_accounts(params = {})
       response = client.get('settlement_accounts', params)
       response['settlement_accounts'].map { |s| SettlementAccount.new(s) }

--- a/spec/integration/reference_spec.rb
+++ b/spec/integration/reference_spec.rb
@@ -34,6 +34,15 @@ describe 'Reference', vcr: true do
     expect(dates.default_conversion_date).to eq('2015-04-30')
   end
 
+  it 'can retrieve #payment_dates' do
+    dates = CurrencyCloud::Reference.payment_dates(currency: 'USD')
+
+    expect(dates.invalid_payment_dates).to_not be_empty
+    invalid_payment_date = dates.invalid_payment_dates.first
+    expect(invalid_payment_date).to eq(['2017-04-29', 'No trading on Saturday'])
+    expect(dates.first_payment_date).to eq('2017-04-28')
+  end
+
   it 'can retrieve #currencies' do
     currencies = CurrencyCloud::Reference.currencies
     expect(currencies).to_not be_empty

--- a/spec/support/vcr_cassettes/Reference/can_retrieve_payment_dates.yml
+++ b/spec/support/vcr_cassettes/Reference/can_retrieve_payment_dates.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devapi.currencycloud.com/v2/reference/payment_dates?currency=USD
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - 1c9da5726314246acfb09ec5651307a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2015 21:04:08 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '743'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - '2775201681275056976'
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: UTF-8
+      string: '{"invalid_payment_dates":{"2017-04-29":"No trading on Saturday","2017-04-30":"No trading on Sunday","2017-05-06":"No trading on Saturday","2017-05-07":"No trading on Sunday","2017-05-13":"No trading on Saturday","2017-05-14":"No trading on Sunday","2017-05-20":"No trading on Saturday","2017-05-21":"No trading on Sunday","2017-05-27":"No trading on Saturday","2017-05-28":"No trading on Sunday","2017-05-29":"","2017-06-03":"No trading on Saturday","2017-06-04":"No trading on Sunday","2017-06-10":"No trading on Saturday","2017-06-11":"No trading on Sunday","2017-06-17":"No trading on Saturday","2017-06-18":"No trading on Sunday","2017-06-24":"No trading on Saturday","2017-06-25":"No trading on Sunday"},"first_payment_date":"2017-04-28"}'
+    http_version:
+  recorded_at: Wed, 29 Apr 2015 21:04:08 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Adds a method for Reference.payment_dates

Fixes https://github.com/CurrencyCloud/currencycloud-ruby/issues/7

I had to fiddle with another vcr cassette to get the spec passing...