### PR TITLE
Don't iterate over error messages unless there's one

### DIFF
--- a/lib/currency_cloud/errors/api_error.rb
+++ b/lib/currency_cloud/errors/api_error.rb
@@ -33,6 +33,8 @@ module CurrencyCloud
       errors = raw_response.parsed_response
       @code = errors['error_code']
       @messages = []
+      
+      return unless errors['error_messages']
 
       errors['error_messages'].each do |field, messages|
         messages.each do |message|


### PR DESCRIPTION
We're seeing a lot of issues where we're getting the following response from the API/gem:

```
NoMethodError: undefined method `each' for nil:NilClass
  from currency_cloud/errors/api_error.rb:37:in `initialize'
  from currency_cloud/response_handler.rb:32:in `new'
  from currency_cloud/response_handler.rb:32:in `handle_failure'
  from currency_cloud/response_handler.rb:14:in `process'
  from currency_cloud/request_handler.rb:42:in `retry_authenticate'
  from currency_cloud/request_handler.rb:17:in `post'
  from currency_cloud/client.rb:12:in `post'
  from currency_cloud/actions/create.
```

It looks like the gem tries to iterate over errors without an error message. Skipping those in order to reach the real error message?