### PR TITLE
Fix failing tests for Ruby 1.9.3

### DIFF
--- a/currency_cloud.gemspec
+++ b/currency_cloud.gemspec
@@ -14,7 +14,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency('httparty', '~> 0.14')
-  s.add_dependency('json', '>= 1.8')
+  if RUBY_VERSION == '1.9.3'
+    s.add_dependency('json', '>= 1.8', '<= 2.2')
+  else
+    s.add_dependency('json', '>= 1.8')
+  end
+
 
   s.add_development_dependency('addressable', '<= 2.4.0')
   s.add_development_dependency('rake', '~> 10.3')


### PR DESCRIPTION
The ruby tests with ruby 1.9.3 suddenly started failing. This was tracked to a change in the json gem version (2.2.0 -> 2.3.0) which was loaded by the bundler