### PR TITLE
Only look for resourceful collections within the CurrencyCloud namespace

### DIFF
--- a/lib/currency_cloud/actions/find.rb
+++ b/lib/currency_cloud/actions/find.rb
@@ -14,10 +14,10 @@ module CurrencyCloud
       private
 
       def mixin_class
-        unless CurrencyCloud.const_defined?(resource.capitalize)
+        unless CurrencyCloud.const_defined?(resource.capitalize, false)
           CurrencyCloud.const_set(resource.capitalize, Class.new(CurrencyCloud::ResourcefulCollection))
         end
-        CurrencyCloud.const_get(resource.capitalize)
+        CurrencyCloud.const_get(resource.capitalize, false)
       end
     end
   end

--- a/spec/integration/actions_spec.rb
+++ b/spec/integration/actions_spec.rb
@@ -72,6 +72,18 @@ describe 'Actions', vcr: true do
     expect(pagination.order_asc_desc).to eq('asc')
   end
 
+  it 'can #find when a top-level module that matches a CurrencyCloud resourceful collection already exists' do
+    # Unset the CurrencyCloud::Beneficiaries method to get it to a state
+    # before any other test attempted to call #find
+    CurrencyCloud.send(:remove_const, :Beneficiaries)
+
+    # Define a Beneficiaries method anywhere above
+    # CurrencyCloud in the resolution chain.
+    Object.const_set(:Beneficiaries, Module.new)
+
+    expect { CurrencyCloud::Beneficiary.find }.not_to raise_exception
+  end
+
   it 'can #update' do
     beneficiary = CurrencyCloud::Beneficiary.update('081596c9-02de-483e-9f2a-4cf55dcdf98c', bank_account_holder_name: 'Test User 2')
     expect(beneficiary).to be_a_kind_of(CurrencyCloud::Beneficiary)

--- a/spec/support/vcr_cassettes/Actions/can_find_when_a_top-level_module_that_matches_a_CurrencyCloud_resourceful_collection_already_exists.yml
+++ b/spec/support/vcr_cassettes/Actions/can_find_when_a_top-level_module_that_matches_a_CurrencyCloud_resourceful_collection_already_exists.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devapi.currencycloud.com/v2/beneficiaries/find
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - e5070d4a16c5ffe4ed9fb268a2a716be
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 25 Apr 2015 09:24:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '1197'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - '2771950395117221003'
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: UTF-8
+      string: '{"beneficiaries":[{"id":"081596c9-02de-483e-9f2a-4cf55dcdf98c","bank_account_holder_name":"Test+User","name":"Test+User","email":null,"payment_types":["regular"],"beneficiary_address":[],"beneficiary_country":null,"beneficiary_entity_type":null,"beneficiary_company_name":null,"beneficiary_first_name":null,"beneficiary_last_name":null,"beneficiary_city":null,"beneficiary_postcode":null,"beneficiary_state_or_province":null,"beneficiary_date_of_birth":null,"beneficiary_identification_type":null,"beneficiary_identification_value":null,"bank_country":"GB","bank_name":"HSBC
+        BANK PLC","bank_account_type":null,"currency":"GBP","account_number":"12345678","routing_code_type_1":"sort_code","routing_code_value_1":"123456","routing_code_type_2":null,"routing_code_value_2":null,"bic_swift":null,"iban":null,"default_beneficiary":"false","creator_contact_id":"c4d838e8-1625-44c6-a9fb-39bcb1fe353d","bank_address":["5
+        Wimbledon Hill Rd","Wimbledon","London"],"created_at":"2015-04-25T09:21:00+00:00","updated_at":"2015-04-25T09:21:00+00:00"}],"pagination":{"total_entries":1,"total_pages":1,"current_page":1,"per_page":25,"previous_page":-1,"next_page":-1,"order":"created_at","order_asc_desc":"asc"}}'
+    http_version:
+  recorded_at: Sat, 25 Apr 2015 09:24:25 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
The current implementation fails on #find methods if the client application has a top-level class for module that matches the name used for a resourceful collection in CurrencyCloud.

E.g. this code will fail:

```ruby
class Beneficiaries; end

CurrencyCloud::Beneficiary.find # raises NoMethodError
```

This is because of how `const_defined?` and `const_get` are used in `CurrencyCloud::Actions::Find`.

The second argument to these methods is `inherit` and by default it’s set to true. Which means that `const_defined?` will attempt to look for a class anywhere in the class resolution chain. So `CurrencyCloud.const_get(:Beneficiaries)` will resolve to `::Beneficiaries`.

The correct behaviour would only look for this class within the `CurrencyCloud` namespace, which is what setting the second argument to `true` will do.

I created a test case that demonstrates this, but wasn’t sure if you’d prefer to be within the existing #find test or as a separate example (which is what I did).