### PR TITLE
Ruby version deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Once a feature has been marked as deprecated, we no longer develop the code or i
 ```
 2025-05-13
 - GET /payments/{id}/submission (to be removed 2025-10-01)
+
+2025-07-07
+- Remove support for Ruby versions 2.5, 2.6 and 2.7
 ```
 
 # Security Consideration


### PR DESCRIPTION
Deprecation notice for ruby versions [2.5, 2.6, 2.7]